### PR TITLE
[Feat] 소유 음식의 양 / 단위 관련 로직 및 api 작업

### DIFF
--- a/src/main/java/org/chefcrew/common/enums/AmountUnit.java
+++ b/src/main/java/org/chefcrew/common/enums/AmountUnit.java
@@ -1,0 +1,7 @@
+package org.chefcrew.common.enums;
+
+public enum AmountUnit {
+    KG, G, MG,
+    ML, L,
+    EA
+}

--- a/src/main/java/org/chefcrew/food/controller/FoodController.java
+++ b/src/main/java/org/chefcrew/food/controller/FoodController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.chefcrew.config.UserId;
 import org.chefcrew.food.dto.request.AddFoodRequest;
 import org.chefcrew.food.dto.request.DeleteFoodRequest;
+import org.chefcrew.food.dto.request.PostAmountUpdateRequest;
 import org.chefcrew.food.dto.response.GetOwnFoodResponse;
 import org.chefcrew.food.service.FoodService;
 import org.springframework.http.ResponseEntity;
@@ -35,6 +36,16 @@ public class FoodController {
     ) {
         return ResponseEntity.ok()
                 .body(new GetOwnFoodResponse(foodService.getOwnedFoodList(userId)));
+    }
+
+    //먹은 양 체크하는 api
+    @PostMapping("/amount-update")
+    private ResponseEntity<Void> updateFoodAmount(
+            @UserId long userId,
+            @RequestBody PostAmountUpdateRequest requestBody
+    ){
+        foodService.updateFoodAmount(userId, requestBody);
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping

--- a/src/main/java/org/chefcrew/food/domain/FoodAmount.java
+++ b/src/main/java/org/chefcrew/food/domain/FoodAmount.java
@@ -1,0 +1,11 @@
+package org.chefcrew.food.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class FoodAmount {
+    long foodId;
+    float amount;
+}

--- a/src/main/java/org/chefcrew/food/dto/FoodData.java
+++ b/src/main/java/org/chefcrew/food/dto/FoodData.java
@@ -1,0 +1,12 @@
+package org.chefcrew.food.dto;
+
+import lombok.Getter;
+import org.chefcrew.common.enums.AmountUnit;
+
+@Getter
+public class FoodData {
+    private long foodId;
+    private String foodName;
+    private float amount;
+    private AmountUnit unit;
+}

--- a/src/main/java/org/chefcrew/food/dto/FoodResponseData.java
+++ b/src/main/java/org/chefcrew/food/dto/FoodResponseData.java
@@ -1,0 +1,11 @@
+package org.chefcrew.food.dto;
+
+import org.chefcrew.common.enums.AmountUnit;
+
+public class FoodResponseData {
+    private long foodId;
+    private String foodName;
+    private float amount;
+    private AmountUnit unit;
+    private String imgUrl;
+}

--- a/src/main/java/org/chefcrew/food/dto/FoodResponseData.java
+++ b/src/main/java/org/chefcrew/food/dto/FoodResponseData.java
@@ -1,7 +1,11 @@
 package org.chefcrew.food.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.chefcrew.common.enums.AmountUnit;
 
+@Getter
+@AllArgsConstructor
 public class FoodResponseData {
     private long foodId;
     private String foodName;

--- a/src/main/java/org/chefcrew/food/dto/request/AddFoodRequest.java
+++ b/src/main/java/org/chefcrew/food/dto/request/AddFoodRequest.java
@@ -1,8 +1,9 @@
 package org.chefcrew.food.dto.request;
 
 import java.util.List;
+import org.chefcrew.food.dto.FoodData;
 
 public record AddFoodRequest(
-        List<String> foodNameList
+        List<FoodData> foodList
 ) {
 }

--- a/src/main/java/org/chefcrew/food/dto/request/DeleteFoodRequest.java
+++ b/src/main/java/org/chefcrew/food/dto/request/DeleteFoodRequest.java
@@ -3,6 +3,6 @@ package org.chefcrew.food.dto.request;
 import java.util.List;
 
 public record DeleteFoodRequest(
-        List<String> foodNameList
+        List<Long> foodIdList
 ) {
 }

--- a/src/main/java/org/chefcrew/food/dto/request/PostAmountUpdateRequest.java
+++ b/src/main/java/org/chefcrew/food/dto/request/PostAmountUpdateRequest.java
@@ -1,0 +1,9 @@
+package org.chefcrew.food.dto.request;
+
+import java.util.List;
+import org.chefcrew.food.dto.FoodData;
+
+public record PostAmountUpdateRequest(
+        List<FoodData> foodDataList
+) {
+}

--- a/src/main/java/org/chefcrew/food/dto/response/GetOwnFoodResponse.java
+++ b/src/main/java/org/chefcrew/food/dto/response/GetOwnFoodResponse.java
@@ -1,9 +1,9 @@
 package org.chefcrew.food.dto.response;
 
 import java.util.List;
-import org.chefcrew.food.dto.FoodData;
+import org.chefcrew.food.dto.FoodResponseData;
 
 public record GetOwnFoodResponse(
-        List<FoodData> ownFoodList
+        List<FoodResponseData> ownFoodList
 ) {
 }

--- a/src/main/java/org/chefcrew/food/dto/response/GetOwnFoodResponse.java
+++ b/src/main/java/org/chefcrew/food/dto/response/GetOwnFoodResponse.java
@@ -1,8 +1,9 @@
 package org.chefcrew.food.dto.response;
 
 import java.util.List;
+import org.chefcrew.food.dto.FoodData;
 
 public record GetOwnFoodResponse(
-        List<String> ownFoodNameList
+        List<FoodData> ownFoodList
 ) {
 }

--- a/src/main/java/org/chefcrew/food/entity/Food.java
+++ b/src/main/java/org/chefcrew/food/entity/Food.java
@@ -24,11 +24,13 @@ public class Food {
     private AmountUnit amountUnit;
 
     private long userId;
+    private String imgUrl; //S3작업시 관련 코드 수정 예정
 
-    public Food(String name, float foodAmount, AmountUnit amountUnit, long userId) {
+    public Food(String name, float foodAmount, AmountUnit amountUnit, String imgUrl, long userId) {
         this.foodName = name;
         this.foodAmount = foodAmount;
         this.amountUnit = amountUnit;
+        this.imgUrl = imgUrl;
         this.userId = userId;
     }
 }

--- a/src/main/java/org/chefcrew/food/entity/Food.java
+++ b/src/main/java/org/chefcrew/food/entity/Food.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.chefcrew.common.enums.AmountUnit;
 
 @Entity
 @Slf4j
@@ -18,10 +19,16 @@ public class Food {
 
     private String foodName;
 
+    private float foodAmount;
+
+    private AmountUnit amountUnit;
+
     private long userId;
 
-    public Food(String name, long userId) {
+    public Food(String name, float foodAmount, AmountUnit amountUnit, long userId) {
         this.foodName = name;
+        this.foodAmount = foodAmount;
+        this.amountUnit = amountUnit;
         this.userId = userId;
     }
 }

--- a/src/main/java/org/chefcrew/food/entity/Food.java
+++ b/src/main/java/org/chefcrew/food/entity/Food.java
@@ -33,4 +33,8 @@ public class Food {
         this.imgUrl = imgUrl;
         this.userId = userId;
     }
+
+    public void updateAmount(float amount){
+        this.foodAmount = amount;
+    }
 }

--- a/src/main/java/org/chefcrew/food/repository/FoodRepository.java
+++ b/src/main/java/org/chefcrew/food/repository/FoodRepository.java
@@ -2,10 +2,12 @@ package org.chefcrew.food.repository;
 
 import static org.chefcrew.food.entity.QFood.food;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPADeleteClause;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.util.List;
+import org.chefcrew.food.domain.FoodAmount;
 import org.chefcrew.food.entity.Food;
 import org.chefcrew.user.entity.User;
 import org.springframework.stereotype.Repository;
@@ -67,5 +69,21 @@ public class FoodRepository {
                 .where(food.foodId.in(foodIdList))
                 .execute();
         em.flush();
+    }
+
+    public List<Food> getByUserIdAndFoodId(long userId, List<FoodAmount> foodAmountList) {
+        BooleanBuilder builder = new BooleanBuilder();
+        for (FoodAmount foodAmount : foodAmountList) {
+            builder.or(
+                    food.foodId.eq(foodAmount.getFoodId())
+                            .and(food.userId.eq(userId))
+            );
+        }
+
+        List<Food> result = query
+                .selectFrom(food)
+                .where(builder)
+                .fetch();
+        return result;
     }
 }

--- a/src/main/java/org/chefcrew/food/repository/FoodRepository.java
+++ b/src/main/java/org/chefcrew/food/repository/FoodRepository.java
@@ -41,9 +41,9 @@ public class FoodRepository {
         return count != null && count > 0;
     }
 
-    public void deleteFood(long userId, List<String> foodNameList) {
+    public void deleteFood(long userId, List<Long> foodIdList) {
         new JPADeleteClause(em, food)
-                .where(food.foodName.in(foodNameList)
+                .where(food.foodId.in(foodIdList)
                         .and(food.userId.eq(userId)))
                 .execute();
     }

--- a/src/main/java/org/chefcrew/food/service/FoodService.java
+++ b/src/main/java/org/chefcrew/food/service/FoodService.java
@@ -5,12 +5,17 @@ import static org.chefcrew.common.exception.ErrorException.USER_NOT_FOUND;
 import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.chefcrew.common.exception.CustomException;
+import org.chefcrew.food.domain.FoodAmount;
+import org.chefcrew.food.dto.FoodData;
 import org.chefcrew.food.dto.FoodResponseData;
 import org.chefcrew.food.dto.request.AddFoodRequest;
 import org.chefcrew.food.dto.request.DeleteFoodRequest;
+import org.chefcrew.food.dto.request.PostAmountUpdateRequest;
 import org.chefcrew.food.entity.Food;
 import org.chefcrew.food.repository.FoodRepository;
 import org.chefcrew.user.entity.User;
@@ -69,5 +74,27 @@ public class FoodService {
         List<Food> foods = foodRepository.getAllByUser(user);
         foodRepository.deleteAllById(foods.stream().map(
                 (Food::getFoodId)).collect(Collectors.toList()));
+    }
+
+    public void updateFoodAmount(long userId, PostAmountUpdateRequest postAmountUpdateRequest){
+        List<FoodData> foodDataList = postAmountUpdateRequest.foodDataList();
+        List<FoodAmount> foodAmountList = getFoodAmountList(foodDataList);
+        List<Food> originDataList = foodRepository.getByUserIdAndFoodId(userId, foodAmountList);
+
+        Map<Long, Food> foodMap = originDataList.stream()
+                .collect(Collectors.toMap(Food::getFoodId, Function.identity()));
+
+        for(FoodAmount requestData: foodAmountList) {
+            Food food = foodMap.get(requestData.getFoodId());
+
+            if (food != null) {
+                food.updateAmount(requestData.getAmount());
+            }
+        }
+    }
+
+    public List<FoodAmount> getFoodAmountList(List<FoodData> foodDataList){
+        return foodDataList.stream().map(foodData -> new FoodAmount(foodData.getFoodId(), foodData.getAmount()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/chefcrew/food/service/FoodService.java
+++ b/src/main/java/org/chefcrew/food/service/FoodService.java
@@ -67,7 +67,7 @@ public class FoodService {
     }
 
     public void deleteFood(long userId, DeleteFoodRequest deleteFoodRequest) {
-        foodRepository.deleteFood(userId, deleteFoodRequest.foodNameList());
+        foodRepository.deleteFood(userId, deleteFoodRequest.foodIdList());
     }
 
     public void deleteAllByUser(User user) throws IOException {

--- a/src/main/java/org/chefcrew/food/service/FoodService.java
+++ b/src/main/java/org/chefcrew/food/service/FoodService.java
@@ -26,12 +26,15 @@ public class FoodService {
     @Transactional
     public void saveFoodList(long userId, AddFoodRequest foodAddRequest) {
         validateUser(userId);
-        List<Food> foodDataList = foodAddRequest.foodNameList().stream()
-                .filter(name -> !foodRepository.existsByFoodNameAndUserId(name, userId))
-                .map(name -> new Food(name, userId))
+
+        //신규 등장한 음식 데이터 저장
+        List<Food> foodList = foodAddRequest.foodList().stream()
+                .map(food -> new Food(food.getFoodName(), food.getAmount(), food.getUnit(), null,
+                        userId)) //TODO 이미지 관련 작업 진행 예정
                 .toList();
-        if (foodDataList != null) {
-            foodDataList.forEach(foodRepository::saveFood);
+
+        if (foodList != null) {
+            foodList.forEach(foodRepository::saveFood);
         }
     }
 

--- a/src/main/java/org/chefcrew/food/service/FoodService.java
+++ b/src/main/java/org/chefcrew/food/service/FoodService.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.chefcrew.common.exception.CustomException;
+import org.chefcrew.food.dto.FoodResponseData;
 import org.chefcrew.food.dto.request.AddFoodRequest;
 import org.chefcrew.food.dto.request.DeleteFoodRequest;
 import org.chefcrew.food.entity.Food;
@@ -44,14 +45,16 @@ public class FoodService {
         }
     }
 
-    public List<String> getOwnedFoodList(long userId) {
+    public List<FoodResponseData> getOwnedFoodList(long userId) {
         validateUser(userId);
         if (!foodRepository.existsByUserId(userId)) {
             return null;
         }
         List<Food> foodList = foodRepository.findByUserId(userId);
         if (foodList != null) {
-            return foodList.stream().map(food -> food.getFoodName())
+            return foodList.stream()
+                    .map(food -> new FoodResponseData(food.getFoodId(), food.getFoodName(), food.getFoodAmount(),
+                            food.getAmountUnit(), food.getImgUrl()))
                     .collect(Collectors.toList());
         } else {
             return null;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
close #36 
추가된 기능 및 기획에 따라 기존 코드 리팩터링 및 api 신규 추가
양 및 단위 관련 기능 추가
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
음식 구분시 동일 음식명으로 다른 상품 존재 가능성 확인으로
다 먹은 음식 삭제 api에서 음식 구분 기준을 id값으로 수정
<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항
- 양/ 단위 관련 클래스 추가
- 기존 food 클래스에 양/단위/imgurl 포함하도록 수정
- 소유 음식 양 수정 api 신규 구현
- 조회 api에  이미지 url 포함하도록 수정
- 다먹은 음식 삭제 api 에서 request 및 삭제 로직에서 id사용하도록 리팩터링
<br>

## 5. 추가 사항
- 이미지 관련 작업은 배포 후 진행 예정