### PR TITLE
[Feat] 카카오 소셜로그인 시 인가코드로 토큰 발급 과정 추가

### DIFF
--- a/src/main/java/org/chefcrew/auth/controller/AuthController.java
+++ b/src/main/java/org/chefcrew/auth/controller/AuthController.java
@@ -33,27 +33,35 @@ public class AuthController {
 
     @PostMapping("/token")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<TokenResponse> reissueToken(@RequestHeader String refreshToken) {
+    public ResponseEntity<TokenResponse> reissueToken(
+            @RequestHeader String refreshToken
+    ) {
         return ResponseEntity.ok(authService.issueToken(refreshToken));
     }
 
     @PostMapping("/sign-out")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity signOut(@UserId Long userId) {
+    public ResponseEntity signOut(
+            @UserId Long userId
+    ) {
         authService.signOut(userId);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/withdraw")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity withdraw(@UserId Long userId) {
+    public ResponseEntity withdraw(
+            @UserId Long userId
+    ) {
         authService.withdraw(userId);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/token/health")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<TokenHealthDto> checkHealthOfToken(@RequestHeader String token) {
+    public ResponseEntity<TokenHealthDto> checkHealthOfToken(
+            @RequestHeader String token
+    ) {
         return ResponseEntity.ok(authService.checkHealthOfToken(token));
     }
 }

--- a/src/main/java/org/chefcrew/auth/controller/AuthController.java
+++ b/src/main/java/org/chefcrew/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package org.chefcrew.auth.controller;
 
 import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.chefcrew.auth.dto.response.SignInResponse;
 import org.chefcrew.auth.dto.response.TokenHealthDto;
@@ -26,9 +28,11 @@ public class AuthController {
     @PostMapping
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<SignInResponse> signIn(
-            @RequestParam("code") String code
+            @RequestParam("code") String code,
+            HttpServletRequest request
     ) throws IOException {
-        return ResponseEntity.ok(authService.signIn(code));
+        String currentDomain = request.getServerName();
+        return ResponseEntity.ok(authService.signIn(code, currentDomain));
     }
 
     @PostMapping("/token")

--- a/src/main/java/org/chefcrew/auth/service/AuthService.java
+++ b/src/main/java/org/chefcrew/auth/service/AuthService.java
@@ -1,6 +1,5 @@
 package org.chefcrew.auth.service;
 
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.chefcrew.auth.dto.response.SignInResponse;
@@ -18,6 +17,8 @@ import org.chefcrew.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
 
 @Slf4j
 @Service
@@ -39,8 +40,8 @@ public class AuthService {
     private String BASIC_THUMBNAIL;
 
     @Transactional
-    public SignInResponse signIn(String socialAccessToken) throws IOException {
-        LoginResult loginResult = login(socialAccessToken);
+    public SignInResponse signIn(String code, String domainName) throws IOException {
+        LoginResult loginResult = login(code, domainName);
         String socialId = loginResult.id();
         String profileImage = loginResult.profile();
         String nickname = loginResult.nickname();
@@ -96,7 +97,8 @@ public class AuthService {
         user.updateRefreshToken(null);
     }
 
-    private LoginResult login(String socialAccessToken) {
+    private LoginResult login(String code, String domainName) {
+        String socialAccessToken = kakaoSignInService.getAccessToken(code, domainName);
         return kakaoSignInService.getKaKaoUserData(socialAccessToken);
     }
 

--- a/src/main/java/org/chefcrew/food/controller/FoodController.java
+++ b/src/main/java/org/chefcrew/food/controller/FoodController.java
@@ -23,7 +23,7 @@ public class FoodController {
 
     @PostMapping
     public ResponseEntity<Void> saveNewFoodList(
-            @UserId long userId,
+            @UserId Long userId,
             @RequestBody AddFoodRequest requestBody
     ) {
         foodService.saveFoodList(userId, requestBody);
@@ -32,7 +32,7 @@ public class FoodController {
 
     @GetMapping("/ownlist")
     private ResponseEntity<GetOwnFoodResponse> getOwnFoodList(
-            @UserId long userId
+            @UserId Long userId
     ) {
         return ResponseEntity.ok()
                 .body(new GetOwnFoodResponse(foodService.getOwnedFoodList(userId)));
@@ -41,7 +41,7 @@ public class FoodController {
     //먹은 양 체크하는 api
     @PostMapping("/amount-update")
     private ResponseEntity<Void> updateFoodAmount(
-            @UserId long userId,
+            @UserId Long userId,
             @RequestBody PostAmountUpdateRequest requestBody
     ){
         foodService.updateFoodAmount(userId, requestBody);
@@ -50,7 +50,7 @@ public class FoodController {
 
     @DeleteMapping
     private ResponseEntity<Void> deleteUsedFood(
-            @UserId long userId,
+            @UserId Long userId,
             @RequestBody DeleteFoodRequest requestBody) {
         foodService.deleteFood(userId, requestBody);
         return ResponseEntity.ok().build();

--- a/src/main/java/org/chefcrew/food/entity/Food.java
+++ b/src/main/java/org/chefcrew/food/entity/Food.java
@@ -21,6 +21,7 @@ public class Food {
 
     private float foodAmount;
 
+    @Enumerated(EnumType.STRING)
     private AmountUnit amountUnit;
 
     private long userId;

--- a/src/main/java/org/chefcrew/recipe/controller/RecipeController.java
+++ b/src/main/java/org/chefcrew/recipe/controller/RecipeController.java
@@ -31,7 +31,7 @@ public class RecipeController {
 
     @PostMapping("/used")
     public ResponseEntity<Void> postAsUsedRecipe(
-            @UserId long userId,
+            @UserId Long userId,
             @RequestBody PostUsedRecipeRequest requestBody) {
         recipeFacade.postAsUsedRecipe(userId, requestBody);
         return ResponseEntity.ok().build();
@@ -39,7 +39,7 @@ public class RecipeController {
 
     @GetMapping("/used")
     public ResponseEntity<GetUsedRecipeListResponse> getUsedRecipeList(
-            @UserId long userId
+            @UserId Long userId
     ) {
         return ResponseEntity.ok(recipeFacade.getUsedRecipeList(userId));
     }

--- a/src/main/java/org/chefcrew/recipe/entity/BasicRecipeInfo.java
+++ b/src/main/java/org/chefcrew/recipe/entity/BasicRecipeInfo.java
@@ -22,5 +22,5 @@ public class BasicRecipeInfo{
         long recipeId;
         String recipeName;
         String recipeSumry;
-        NationOption nationOption;
+        //NationOption nationOption;
 }

--- a/src/main/java/org/chefcrew/user/controller/UserController.java
+++ b/src/main/java/org/chefcrew/user/controller/UserController.java
@@ -17,7 +17,7 @@ public class UserController {
 
     @GetMapping
     public ResponseEntity<GetUserInfoResponse> getUserInfo(
-            @UserId long userId
+            @UserId Long userId
     ) {
         return ResponseEntity.ok().body(userService.getUserInfo(userId));
     }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
close #40 
로그인 api 에서 프론트와 각 파트에서 처리 영역 협의 후 api 로직 수정 진행
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
로컬/배포 상황 별 리다이렉트 uri 분리 필요성 파악
<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항
로컬/배포 상황 별 리다이렉트 uri 부여 메서드 추가
카카오 서버와 통신하여 토큰 발급 과정 추가
<br>

## 5. 추가 사항
토큰 상태 구분을 위한 필터를 차후 구현 예정
