### PR TITLE
[hotfix/#66] 기존 유저정보 업데이트 조건 수정 및 이미지 수정 로직 추가

### DIFF
--- a/src/main/java/org/chefcrew/auth/service/AuthService.java
+++ b/src/main/java/org/chefcrew/auth/service/AuthService.java
@@ -60,9 +60,15 @@ public class AuthService {
                     .build();
             userRepository.save(newUser);
 
-        } else if (isSignedUserButEmailNotSaved(socialId)) {
+        } else if (isAlreadySignedUser(socialId)) {
             userRepository.findBySocialId(socialId).ifPresent(user -> {
-                user.updateEmail(email);
+                if(isSignedUserButEmailNotSaved(socialId) || !user.getEmail().equals(email)){
+                    user.updateEmail(email);
+                }
+                if(!user.getProfile().equals(profileImage)) {
+                    user.updateProfile(profileImage);
+                }
+
             });
         }
 
@@ -74,11 +80,7 @@ public class AuthService {
         String refreshToken = jwtService.issuedToken(String.valueOf(user.getUserId()), TOKEN_EXPIRATION_TIME_REFRESH, REFRESH_TOKEN);
 
         user.updateRefreshToken(refreshToken);
-        user.updateProfile(BASIC_ROOT + BASIC_THUMBNAIL);
 
-        if (nickname != null) {
-            user.updateNickname(nickname);
-        }
         return SignInResponse.of(user.getUserId(), accessToken, refreshToken, isAlreadySignedUser(socialId),
                 user.getProfile());
     }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
유저 db 업데이트 관련 이슈 해결
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
유저 db 업데이트 트리거가 이메일 마이그레이션 상황에만 설정되어 있었습니다.
따라서 로그인 시 기존 회원일 경우, 카카오에서의 정보와 동기화되야하는 필드에 대해 필드값과 카카오 응답값의 일치 여부에 따라 업데이트하도록 로직을 보완했습니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항
- 유저 데이터 업데이트 로직 보완 및 리팩터링
<br>

## 5. 추가 사항
